### PR TITLE
🔧 ajustado regra de cadastro de venda de produtos

### DIFF
--- a/backend/BE.Application/Features/Products/Commands/GetProductsCommand/GetProductsCommandHandler.cs
+++ b/backend/BE.Application/Features/Products/Commands/GetProductsCommand/GetProductsCommandHandler.cs
@@ -17,7 +17,8 @@ public class GetProductsCommandHandler(IProductsRepository productsRepository) :
                     Name = p.Name, 
                     Price = p.Price, 
                     Stock = p.Stock,
-                    Description = p.Description
+                    Description = p.Description,
+                    IsActive = p.IsActive
                 }).ToList(),
             Page = request.Page,
             Size = products.Count

--- a/backend/BE.Application/Features/Products/Commands/GetProductsCommand/GetProductsResult.cs
+++ b/backend/BE.Application/Features/Products/Commands/GetProductsCommand/GetProductsResult.cs
@@ -30,5 +30,8 @@ public class ProductsSimpleResult
     
     [JsonPropertyName("description")]
 	public string? Description { get; set; }
+	
+	[JsonPropertyName("is_active")]
+	public bool IsActive { get; set; }
 }
 

--- a/backend/BE.Application/Features/Sales/Commands/CreateSaleCommand/CreateSaleCommandHandler.cs
+++ b/backend/BE.Application/Features/Sales/Commands/CreateSaleCommand/CreateSaleCommandHandler.cs
@@ -9,18 +9,47 @@ public class CreateSaleCommandHandler(IProductsRepository productRepository, ISa
 {
     public async Task<CreateSaleResult> Handle(CreateSaleCommand request, CancellationToken ct)
     {
-        var validator = new CreateSaleValidator();
-        var resultValidation = await validator.ValidateAsync(request, ct);
+	    try
+	    {
+		    var validator = new CreateSaleValidator();
+		    var resultValidation = await validator.ValidateAsync(request, ct);
 
-        if (!resultValidation.IsValid)
-            throw new BadRequestException(resultValidation);
+		    if (!resultValidation.IsValid)
+			    throw new BadRequestException(resultValidation);
 
-		var sale = CreateSale(request);
-		sale.Itens = await GetSaleItens(request.Products, sale, ct);
+		    var sale = CreateSale(request);
+		    sale.Itens = await GetSaleItens(request.Products, sale, ct);
 
-        var result = await saleRepository.CreateAsync(sale, ct);
+		    if (sale.Itens.Count == 0)
+			    throw new EstoqueProdutoInsuficienteException(Guid.Empty, "Nenhum produto foi adicionado a venda.");
+		    
+		    var result = await saleRepository.CreateAsync(sale, ct);
 
-        return new CreateSaleResult() { SaleId = sale.Id };
+		    return new CreateSaleResult
+		    {
+			    SaleId = result.Id,
+			    Success = true,
+			    Errors = null
+		    };
+	    }
+	    catch (EstoqueProdutoInsuficienteException ex)
+	    {
+		    return new CreateSaleResult()
+		    {
+			    Errors = [ ex.Message ],
+			    Success = false,
+			    SaleId = Guid.Empty
+		    };
+	    }
+	    catch (Exception ex)
+	    {
+		    return new CreateSaleResult()
+		    {
+			    Errors = [ ex.Message ],
+			    Success = false,
+			    SaleId = Guid.Empty
+		    };
+	    }
 	}
 
     private async Task<ICollection<SaleItem>> GetSaleItens(IEnumerable<ProductSaleCommand> products, Sale sale, CancellationToken ct)
@@ -29,9 +58,11 @@ public class CreateSaleCommandHandler(IProductsRepository productRepository, ISa
 
 		foreach (var ps in products)
 		{
-			var product = await productRepository.GetProductAsync(p => p.Id == ps.ProductId, ct);
+			var product = await productRepository.GetProductAsync(p => p.Id == ps.ProductId && p.Stock >= ps.Quantity && p.IsActive, ct);
 			if (product is null)
-				throw new BadRequestException($"Produto de Id {ps.ProductId} não foi encontrado.");
+				throw new EstoqueProdutoInsuficienteException(ps.ProductId, "Verifique se há estoque disponível do produto e se ele está ativo.");
+			product.Stock -= ps.Quantity;
+			productRepository.Update(product);
 			saleItems.Add(new SaleItem(product, ps.Quantity, sale));
 		}
 

--- a/backend/BE.Application/Features/Sales/Commands/CreateSaleCommand/CreateSaleResult.cs
+++ b/backend/BE.Application/Features/Sales/Commands/CreateSaleCommand/CreateSaleResult.cs
@@ -5,5 +5,11 @@ namespace BE.Application.Features.Sales.Commands.CreateSaleCommand;
 public class CreateSaleResult
 {
     [JsonPropertyName("id")]
-    public Guid SaleId { get; set; }
+    public Guid SaleId { get; init; }
+    
+    [JsonPropertyName("success")]
+    public bool Success { get; init; }
+
+    [JsonPropertyName("errors")] 
+    public List<string>? Errors { get; init; }
 }

--- a/backend/BE.Domain/Exception/EstoqueProdutoInsuficienteException.cs
+++ b/backend/BE.Domain/Exception/EstoqueProdutoInsuficienteException.cs
@@ -1,0 +1,8 @@
+﻿using BE.Domain.Entities;
+
+namespace BE.Domain.Exception;
+
+public class EstoqueProdutoInsuficienteException(Guid ProdutoId, string message) : System.Exception(message)
+{
+    
+}

--- a/frontend/FE.Application/Features/Products/CreateProductCommand/CreateProductRequest.cs
+++ b/frontend/FE.Application/Features/Products/CreateProductCommand/CreateProductRequest.cs
@@ -11,6 +11,6 @@ public sealed class CreateProductRequest : IRequest<BaseResponse<CreateProductRe
 	public string? Category { get; set; }
 	public string? Brand { get; set; }
 	public int Stock { get; set; }
-	public bool IsActive { get; set; }
+	public bool IsActive { get; set; } = true;
 	public string? CreatedBy { get; set; }
 }

--- a/frontend/FE.Application/Features/Sales/CreateSaleCommand/CreateSaleResponse.cs
+++ b/frontend/FE.Application/Features/Sales/CreateSaleCommand/CreateSaleResponse.cs
@@ -5,5 +5,11 @@ namespace FE.Application.Features.Sales.CreateSaleCommand;
 public class CreateSaleResponse
 {
 	[JsonPropertyName("id")]
-	public Guid Id { get; set; }
+	public Guid SaleId { get; set; }
+
+	[JsonPropertyName("success")]
+	public bool Success { get; set; }
+
+	[JsonPropertyName("errors")]
+	public List<string>? Errors { get; set; }
 }

--- a/frontend/FE.ViewModels/Features/Product/ProductSimpleViewModel.cs
+++ b/frontend/FE.ViewModels/Features/Product/ProductSimpleViewModel.cs
@@ -6,12 +6,19 @@ public class ProductSimpleViewModel
 {
 	[JsonPropertyName("id")]
 	public Guid Id { get; init; }
+	
 	[JsonPropertyName("name")]
 	public string? Name { get; init; }
+	
 	[JsonPropertyName("price")]
 	public decimal Price { get; init; }
+	
 	[JsonPropertyName("stock_quantity")]
 	public int Stock { get; init; }
+
 	[JsonPropertyName("description")]
 	public string? Description { get; set; }
+
+	[JsonPropertyName("is_active")]
+	public bool IsActive { get; set; }
 }

--- a/frontend/FE.WebApp/Pages/Produtos/ProdutoComponent.razor
+++ b/frontend/FE.WebApp/Pages/Produtos/ProdutoComponent.razor
@@ -32,7 +32,10 @@
         <div class="card-footer">
             <div class="d-flex flex-row justify-content-between">
                 <button type="button" class="btn btn-primary btn-sm" @onclick=@(() => OnSelected?.Invoke(Product))>Editar</button>
-                <button type="button" class="btn btn-secondary btn-sm" @onclick="@(() => OnVendaSelected?.Invoke(Product))">Vender</button>
+                @if (Product?.Stock > 0 && (Product?.IsActive ?? false))
+                {
+                    <button type="button" class="btn btn-secondary btn-sm" @onclick="@(() => OnVendaSelected?.Invoke(Product))">Vender</button>
+                }
             </div>
         </div>
     </AuthorizeView>

--- a/frontend/FE.WebApp/Pages/Vendas/CadastrarVendaProduto.razor
+++ b/frontend/FE.WebApp/Pages/Vendas/CadastrarVendaProduto.razor
@@ -7,7 +7,7 @@
     <Carregando Tipo="Carregando.ECarregandoTipo.Primary" EstaCarregando="_cadastrandoVenda" />
 }else if (_erroCadastarVenda)
 {
-    <Alerta Tipo="Alerta.TipoAlerta.Erro" Mensagem="Ocorreu um erro ao cadastrar a venda. Tente novamente." />
+    <Alerta Tipo="Alerta.TipoAlerta.Erro" Mensagem="@_messageErroCadastrarVenda" />
 }
 
 @if (_editContext is not null)
@@ -17,9 +17,9 @@
     <EditForm EditContext="_editContext" OnValidSubmit="EnviarVenda">
         <AntiforgeryToken />
         <div class="form-group row my-2">
-            <label class="form-label col-md-3 my-auto text-end">Observação:</label>
+            <label class="form-label col-md-3 my-auto text-end">Nome do Produto:</label>
             <div class="col-md-6">
-                <input type="text" class="form-control desabled" value="NomeProduto" disabled />
+                <input type="text" class="form-control desabled" value="@NomeProduto" disabled />
             </div>
         </div>
 

--- a/frontend/FE.WebApp/Pages/Vendas/CadastrarVendaProduto.razor.cs
+++ b/frontend/FE.WebApp/Pages/Vendas/CadastrarVendaProduto.razor.cs
@@ -1,4 +1,5 @@
-﻿using FE.Application.Features.Sales.CreateSaleCommand;
+﻿using System.Diagnostics.CodeAnalysis;
+using FE.Application.Features.Sales.CreateSaleCommand;
 using FE.ViewModels;
 using MediatR;
 using Microsoft.AspNetCore.Components;
@@ -30,6 +31,7 @@ public partial class CadastrarVendaProduto : IDisposable
 
 	private bool _cadastrandoVenda;
 	private bool _erroCadastarVenda;
+	private string _messageErroCadastrarVenda = string.Empty;
 
 	protected override void OnInitialized()
 	{
@@ -49,10 +51,16 @@ public partial class CadastrarVendaProduto : IDisposable
 
 		_request.Itens.Add(new ProductsSale() { Id = Id, Quantity = _quantidade });
 		var resultado = await Mediator.Send(_request);
-		if (resultado is { Status: EStatusResponse.Ok, Dado: not null } && resultado.Dado.Id != Guid.Empty)
-			NavManager.NavigateTo($"vendas-detalhes?id={resultado.Dado.Id}");
+		if (resultado is { Status: EStatusResponse.Ok, Dado.Success: true } && resultado.Dado.SaleId != Guid.Empty)
+			NavManager.NavigateTo($"vendas-detalhes?id={resultado.Dado.SaleId}");
 		else
+		{
 			_erroCadastarVenda = true;
+			_messageErroCadastrarVenda = string.Join(", ", resultado.Dado?.Errors ?? []);
+			if (string.IsNullOrWhiteSpace(_messageErroCadastrarVenda))
+				_messageErroCadastrarVenda = "Ocorreu um erro ao cadastrar a venda. Tente novamente.";
+		}
+			
 
 		_cadastrandoVenda = false;
 		StateHasChanged();


### PR DESCRIPTION
- Quando uma venda é realizada, a quantidade de estoque do produto e reduzida.
- Uma venda não pode ser cadastrada API (e fron-end) se não tiver a quantidade de produto em estoque.
- Uma venda não pode ser cadastrada pela API se o produto não estiver ativo.
- No front-end, a opção de cadastrar avenda somente aparece se o produto tiver pelo menos uma unidade em estoque e estiver ativo.